### PR TITLE
[calligra] Correct Fontconfig variable name.

### DIFF
--- a/rpm/0018-Use-the-camel-case-variable-names-for-Fontconfig.patch
+++ b/rpm/0018-Use-the-camel-case-variable-names-for-Fontconfig.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Damien Caliste <dcaliste@free.fr>
+Date: Tue, 7 Sep 2021 15:13:02 +0200
+Subject: [PATCH] Use the camel case variable names for Fontconfig.
+
+---
+ libs/text/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/text/CMakeLists.txt b/libs/text/CMakeLists.txt
+index 4d7c38dcfa7..889ff5dd241 100644
+--- a/libs/text/CMakeLists.txt
++++ b/libs/text/CMakeLists.txt
+@@ -152,7 +152,7 @@ if( SHOULD_BUILD_FEATURE_RDF )
+ endif()
+ 
+ if( FONTCONFIG_FOUND )
+-    target_link_libraries(kotext PRIVATE ${FONTCONFIG_LIBRARIES})
++    target_link_libraries(kotext PRIVATE ${Fontconfig_LIBRARIES})
+ endif()
+ 
+ if( FREETYPE_FOUND )
+-- 
+2.25.1
+

--- a/rpm/calligra.spec
+++ b/rpm/calligra.spec
@@ -41,6 +41,7 @@ Patch21: 0014-Work-around-QLocale-.timeFormat-.simplified-seg-faul.patch
 Patch22: 0015-Don-t-export-HTML-in-stage.patch
 Patch23: 0016-Adjust-for-old-Qt-version.patch
 Patch24: 0017-Revert-Another-group-of-old-style-connects-migrated-.patch
+Patch25: 0018-Use-the-camel-case-variable-names-for-Fontconfig.patch
 
 %description
 %{summary}.
@@ -193,6 +194,7 @@ BuildRequires:  extra-cmake-modules >= 5.34.0
 %patch22 -d upstream -p1
 %patch23 -d upstream -p1
 %patch24 -d upstream -p1
+%patch25 -d upstream -p1
 
 %define build_kf5() cd %1 ; if [ ! -d build ] ; then mkdir build ; fi ; cd build ; if [ ! -e Makefile ] ; then CMAKE_PREFIX_PATH=%{_buildrootdir}/kf5/usr cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_RPATH=%{_libdir}/calligra-kf5 -DBUILD_TESTING=OFF %{?2} .. ; fi ; make %{?_smp_mflags} install DESTDIR=%{_buildrootdir}/kf5 ; cd ../.. ;
 %build


### PR DESCRIPTION
Calligra builds ok in SDK with this patch, even with the newest extra-cmake-modules.

@pvuorela